### PR TITLE
Fix angular2-materialize depedency on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@angularclass/conventions-loader": "^1.0.13",
     "@angularclass/hmr": "~1.2.2",
     "@angularclass/hmr-loader": "~3.0.2",
-    "angular2-materialize": "file:///Users/rubyboy/Development/Workspace/3rd/angular2-materialize/dist/angular2-materialize-0.0.0-development.tgz",
+    "angular2-materialize": "^15.1.10",
     "core-js": "^2.4.1",
     "hammerjs": "^2.0.8",
     "http-server": "^0.9.0",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
A bug fix on the package.json


* **What is the current behavior?** (You can also link to an open issue here)
It can't do a simple npm install, its broken.


* **What is the new behavior (if this is a feature change)?**
Can do a npm install on the project now.


* **Other information**:
